### PR TITLE
chore: migrate study planner to openrouter ai infra 

### DIFF
--- a/src/lib/ai/generateStudyPlan.ts
+++ b/src/lib/ai/generateStudyPlan.ts
@@ -6,29 +6,28 @@ export const generateStudyPlan = async (data: StudyPlanRequest) => {
   const today = new Date()
   const testDate = new Date(data.testDate)
   const daysUntilTest = Math.ceil((testDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
-  const maxDays = Math.min(daysUntilTest, 30)
+  const maxDays = Math.min(daysUntilTest, 30) // cap at 30 days
 
-  const prompt = `You are an expert SAT coach and a JSON-only response generator.
+  const prompt = `
+You are an expert SAT coach and JSON-only response generator.
 
-Generate a personalized, detailed SAT study plan using the following inputs:
+Generate a personalized SAT study plan that **covers exactly ${maxDays} days**, starting from today (${today.toISOString().split("T")[0]}).  
+
+Inputs:
 - Current SAT score: ${data.currentScore}
 - Target SAT score: ${data.targetScore}
 - Days until test: ${daysUntilTest}
+- Personalization: "${data.personalization}"
 
 Requirements:
-1. Create a day-by-day schedule from today until the test date (maximum 30 days).
-2. For each day, include 2–3 unique study activities, each with:
+1. The plan must include **exactly ${maxDays} days** — no fewer, no more.
+2. For each day, include **2–3 unique study activities** with:
    - topic (e.g., "Reading: Main Idea Questions", "Math: Quadratic Equations")
-   - type (must be either "review" or "practice")
+   - type ("review" or "practice")
    - duration in minutes (integer)
-   - description (50–100 words of specific instructions)
-
-3. Ensure that each activity:
-   - Reflects the user's personalization: ${data.personalization}
-   - Includes steps that help achieve their personalization within their prep
-
-Format:
-Return ONLY a valid and complete JSON object in the EXACT structure below — nothing else.
+   - description (50–100 words, step-by-step instructions)
+3. Spread activities across all SAT sections (Math, Reading, Writing) and **avoid repeating the same topic on consecutive days**.
+4. Return ONLY a valid JSON object, structured exactly like this:
 
 {
   "days": [
@@ -37,7 +36,7 @@ Return ONLY a valid and complete JSON object in the EXACT structure below — no
       "activities": [
         {
           "topic": "string",
-          "type": "string - only one word",
+          "type": "review or practice",
           "duration": number,
           "description": "string"
         }
@@ -47,21 +46,16 @@ Return ONLY a valid and complete JSON object in the EXACT structure below — no
 }
 
 Rules:
-- Do NOT include any explanation or notes before or after the JSON.
-- Ensure there are no trailing commas or invalid characters.
-- The response should be proper JSON that can be parsed by Javascript later on
-`;
+- Do NOT include any explanations, notes, or text outside the JSON.
+- Ensure the JSON is properly formatted and parsable in JavaScript.
+`
+
 
   let retries = 0
 
-
-  // In case AI fails to return valid JSON, we retry up to MAX_RETRIES times
   while (retries <= MAX_RETRIES) {
     try {
-      const response = await axios.post("/api/mistralai", {
-        prompt: prompt
-      })
-
+      const response = await axios.post("/api/mistralai", { prompt })
       const text = typeof response.data === 'string' ? response.data : JSON.stringify(response.data)
       const jsonMatch = text.match(/\{[\s\S]*\}/)
 
@@ -73,7 +67,6 @@ Rules:
       plan.days = plan.days.slice(0, maxDays).map((day: { activities: Activity[] }, index: number) => {
         const date = new Date(currentDate)
         date.setDate(date.getDate() + index)
-
         return {
           ...day,
           date: date.toISOString().split("T")[0],
@@ -84,7 +77,7 @@ Rules:
       return plan
     } catch (error) {
       retries++
-      if (retries > MAX_RETRIES) throw new Error("Failed to generate valid plan after backup retries. Error:" + error)
+      if (retries > MAX_RETRIES) throw new Error("Failed to generate valid plan after retries. Error:" + error)
     }
   }
 }


### PR DESCRIPTION
We previously used Groq, but some other services within our code use OpenRouter (much better imo), so we migrated our AI study planner to that service as well, to only have one singular ai infra (less cost + easier to maintain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Study plans now cover exactly your selected number of days (up to 30), starting today with concrete dates.
  - Each day includes 2–3 activities with topic, type (review or practice), duration, and a clear 50–100 word step-by-step description.
  - Improved balance across SAT sections and avoidance of consecutive topic repeats.

- Bug Fixes
  - More reliable plan generation and parsing to reduce invalid or partial outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->